### PR TITLE
travis: Update shellcheck download URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 install:
     - sudo apt-get update -qq
     - sudo apt-get install -q vim-common file libffi6 libgmp10
-    - curl -L "http://archive.ubuntu.com/ubuntu/pool/universe/s/shellcheck/shellcheck_0.3.7-1_amd64.deb" -o "/tmp/shellcheck_0.3.7-1_amd64.deb"
-    - '[ "$(openssl dgst -sha256 "/tmp/shellcheck_0.3.7-1_amd64.deb" | cut -d " " -f 2)" == "1622b0ebead82475946188c7ace2afe012607c1b064d2888556f296a28cd1927" ]'
-    - sudo dpkg -i "/tmp/shellcheck_0.3.7-1_amd64.deb"
+    - curl -L "http://archive.ubuntu.com/ubuntu/pool/universe/s/shellcheck/shellcheck_0.4.6-1_amd64.deb" -o "/tmp/shellcheck_0.4.6-1_amd64.deb"
+    - '[ "$(openssl dgst -sha256 "/tmp/shellcheck_0.4.6-1_amd64.deb" | cut -d " " -f 2)" == "95b4d2577f25ae47918bd53068a5ff42d5c34e5f884daa8dae32253044b45370" ]'
+    - sudo dpkg -i "/tmp/shellcheck_0.4.6-1_amd64.deb"
 script: make && make test SHELL="bash -x"

--- a/google-font-download
+++ b/google-font-download
@@ -201,7 +201,7 @@ if [ "$format" = "all" ]; then
 	# Deal with the special "all" value
 	formats=("eot" "woff" "woff2" "svg" "ttf")
 else
-	IFS=', ' read -a formats <<< "$format"
+	IFS=', ' read -r -a formats <<< "$format"
 	for f in "${formats[@]}"; do
 		case "$f" in
 			eot|woff|woff2|svg|ttf)
@@ -255,7 +255,7 @@ useragent[svg]='Mozilla/4.0 (iPad; CPU OS 4_0_1 like Mac OS X) AppleWebKit/534.4
 useragent[ttf]='Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) Safari/538.1 Daum/4.1'
 
 # Clear the output file
->"$css"
+true >"$css"
 
 # Loop over the fonts, and download them one-by-one
 errors=0


### PR DESCRIPTION
The old URL no longer works, so we need a newer source.