### PR TITLE
 Allow local font names to be missing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.css
+*.woff2
+*.woff
+*.eot
+*.svg
+*.ttf

--- a/google-font-download
+++ b/google-font-download
@@ -416,15 +416,10 @@ for family in "${families[@]}"; do
 
 	# Determine the local names for the given fonts so we can use a locally-installed font if available.
 	css_src_string=$(echo "$css_string" | grep "src:")
-	ret=0
-	local_name=$(echo "$css_src_string" | grep -Eo "src: local\\('[^']+'\\)," | $ESED "s/^src: local\\('([^']+)'\\),$/\\1/g") || ret=$?
-	if [ $ret -ne 0 ]; then
-		errors=1
-		printf >&2 "Failed to determine local font name\\n"
-	fi
+	local_name=$(echo "$css_src_string" | grep -Eo "src: local\\('[^']+'\\)," | $ESED "s/^src: local\\('([^']+)'\\),$/\\1/g") || true
 	local_postscript_name=$(echo "$css_src_string" | grep -Eo ", local\\('[^']+'\\)," | $ESED "s/^, local\\('([^']+)'\\),$/\\1/g") || true
 
-	# When the local font name couldn't be determined, still produce a valid CSS file
+	# Some fonts don't have a local font name
 	if [ -n "$local_name" ]; then
 		printf >>"$css" "\\t\\tlocal('%s'),\\n" "$local_name"
 	fi


### PR DESCRIPTION
From what I can tell, some fonts now don't provide local font names:
```bash
http GET 'https://fonts.googleapis.com/css?family=Lora&subset=latin'

# HTTP/1.1 200 OK
# 
# @font-face {
#   font-family: 'Lora';
#   font-style: normal;
#   font-weight: 400;
#   src: url(https://fonts.gstatic.com/s/lora/v15/0QI6MX1D_JOuGQbT0gvTJPa787weuxJBkqg.ttf) format('truetype');
# }
```

This PR changes the logic to no longer throw an error when a local font name is missing and also adds an gitignore file.